### PR TITLE
beginning initial build integration with jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+
+  agent any
+
+  stages {
+
+    stage('Checkout') {
+      steps {
+        checkout scm
+        sh 'cp Makefile.default Makefile'
+      }
+    }
+
+    stage('Build') {
+      steps {
+        echo 'building gasoline with pthreads...'
+        sh 'make EXE="gasoline_pthread" pthread'
+        sh 'make clean'
+
+        echo 'building gasoline with mpi...'
+        sh 'make EXE="gasoline_mpi" mpi'
+        sh 'make clean'
+
+        sh 'rm Makefile'
+      }
+    }
+  }
+
+  post {
+    success {
+      echo 'build success'
+    }
+    failure {
+      echo 'build failure'
+    }
+  }
+}


### PR DESCRIPTION
Integrating Jenkinsfile for testing on Imp. There are still build options not yet implemented in the Jenkinsfile (Charm, AMPI) in addition to test suites. The Jenkins server will change over to a GitHub OAuth login strategy once it starts pulling N-BodyShop/gasoline